### PR TITLE
PLAT-16 Nynhex/plat 16 nginx consul image update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM nginx:1.13.7
-MAINTAINER Keith Gable <keith@art19.com>
+FROM nginx:1.15.12
+MAINTAINER Keith Gable <keith@art19.com> James Jelinek <james@art19.com>
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -qq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ COPY nginx.service /etc/service/nginx/run
 COPY consul-template.service /etc/service/consul-template/run
 
 RUN mkdir /etc/consul-template && chmod +x /etc/service/nginx/run && chmod +x /etc/service/consul-template/run
-RUN mkdir /etc/consul-template/conf
+
 CMD ["/usr/bin/runsvdir", "/etc/service"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:1.15.12
-MAINTAINER Keith Gable <keith@art19.com> James Jelinek <james@art19.com>
+MAINTAINER Keith Gable <keith@art19.com>, James Jelinek <james@art19.com>
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -qq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get -y install wget runit unzip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget https://releases.hashicorp.com/consul-template/0.14.0/consul-template_0.14.0_linux_amd64.zip
-RUN unzip -d /usr/local/bin consul-template_0.14.0_linux_amd64.zip
+RUN wget https://releases.hashicorp.com/consul-template/0.20.0/consul-template_0.20.0_linux_amd64.zip
+RUN unzip -d /usr/local/bin consul-template_0.20.0_linux_amd64.zip
 
 COPY nginx.service /etc/service/nginx/run
 COPY consul-template.service /etc/service/consul-template/run
 
 RUN mkdir /etc/consul-template && chmod +x /etc/service/nginx/run && chmod +x /etc/service/consul-template/run
-
+RUN mkdir /etc/consul-template/conf
 CMD ["/usr/bin/runsvdir", "/etc/service"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Supported tags and respective Dockerfile links
 
-- [`latest`](https://github.com/art19/docker-nginx-consul/blob/master/Dockerfile), [`1.13.7_0.14.0`](https://github.com/art19/docker-nginx-consul/blob/1.13.7_0.14.0/Dockerfile)
+- [`latest`](https://github.com/art19/docker-nginx-consul/blob/master/Dockerfile), [`1.15.12`](https://github.com/art19/docker-nginx-consul/blob/1.15.12/Dockerfile)
 
 # Nginx with Consul Template
 


### PR DESCRIPTION
- bumps latest nginx from dockerhub mainstream
- bumps consul-template from hashicorp release

acceptance criteria:
- does it run
- does it not give errors on syntax when executing

notes:
- currently having massively dumb problems with docker on mac, until i can retool would you test this branch on your machine?  I should have my docker re-worker in the next 30m-1h